### PR TITLE
fix special case, when template doesn't exists and vm has deletionTimeStamp

### DIFF
--- a/pkg/webhooks/validating/hook.go
+++ b/pkg/webhooks/validating/hook.go
@@ -48,6 +48,10 @@ func admitVMTemplate(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
 		return webhooks.ToAdmissionResponseError(err)
 	}
 
+	if newVM.DeletionTimestamp != nil {
+		return webhooks.ToAdmissionResponseOK()
+	}
+
 	rules, err := getValidationRulesForVM(newVM)
 	if err != nil {
 		return webhooks.ToAdmissionResponseError(err)


### PR DESCRIPTION
fix special case, when template doesn't exists and vm has deletionTimeStamp
https://bugzilla.redhat.com/show_bug.cgi?id=1780473
/cc fromanirh
Signed-off-by: Karel Simon <ksimon@redhat.com>