### PR TITLE
Remove cpu and memory requests and limits while creating the template-validator pod

### DIFF
--- a/cluster/k8s/manifests/service.yaml
+++ b/cluster/k8s/manifests/service.yaml
@@ -56,15 +56,8 @@ spec:
       serviceAccountName: template-validator
       containers:
         - name: webhook
-          image: quay.io/fromani/kubevirt-template-validator:v0.6.6
+          image: quay.io/kubevirt/kubevirt-template-validator:v0.6.6
           imagePullPolicy: Always
-          resources:
-            limits:
-              memory: 250Mi
-              cpu: 300m
-            requests:
-              memory: 250Mi
-              cpu: 300m
           args:
             - -v=2
             - --port=8443

--- a/cluster/okd/manifests/service.yaml
+++ b/cluster/okd/manifests/service.yaml
@@ -58,15 +58,8 @@ spec:
       serviceAccountName: template-validator
       containers:
         - name: webhook
-          image: quay.io/fromani/kubevirt-template-validator:v0.6.6
+          image: quay.io/kubevirt/kubevirt-template-validator:v0.6.6
           imagePullPolicy: Always
-          resources:
-            limits:
-              memory: 250Mi
-              cpu: 300m
-            requests:
-              memory: 250Mi
-              cpu: 300m
           args:
             - -v=2
             - --port=8443


### PR DESCRIPTION
This patch removes the cpu and memory requests and limits while creating the template-validator pod