### PR TITLE
Evaluate rules for multiple values

### DIFF
--- a/pkg/validation/path.go
+++ b/pkg/validation/path.go
@@ -87,7 +87,11 @@ func (p *Path) Find(vm *k6tv1.VirtualMachine) error {
 }
 
 func (p *Path) Len() int {
-	return len(p.results)
+	totalCount := 0
+	for _, result := range p.results {
+		totalCount += len(result)
+	}
+	return totalCount
 }
 
 func (p *Path) AsString() ([]string, error) {

--- a/pkg/validation/specialized.go
+++ b/pkg/validation/specialized.go
@@ -19,9 +19,11 @@
 package validation
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 
 	k6tv1 "kubevirt.io/client-go/api/v1"
@@ -31,6 +33,8 @@ type RuleApplier interface {
 	Apply(vm, ref *k6tv1.VirtualMachine) (bool, error)
 	String() string
 }
+
+var ErrNoValuesFound = errors.New("no values were found")
 
 // we need a vm reference to specialize a rule because few key fields may
 // be JSONPath, and we need to walk them to get e.g. the value to check,
@@ -58,7 +62,7 @@ type Range struct {
 
 func (r *Range) Decode(Min, Max interface{}, vm, ref *k6tv1.VirtualMachine) error {
 	if Min != nil {
-		v, err := decodeInt64(Min, vm, ref)
+		v, err := decodeInt(Min, vm, ref)
 		if err != nil {
 			return err
 		}
@@ -66,7 +70,7 @@ func (r *Range) Decode(Min, Max interface{}, vm, ref *k6tv1.VirtualMachine) erro
 		r.MinSet = true
 	}
 	if Max != nil {
-		v, err := decodeInt64(Max, vm, ref)
+		v, err := decodeInt(Max, vm, ref)
 
 		if err != nil {
 			return err
@@ -87,28 +91,11 @@ func (r *Range) Includes(v int64) bool {
 	return true
 }
 
-// can't be a Stringer
-func (r *Range) ToString(v int64) string {
-	cond := ""
-	if !r.Includes(v) {
-		cond = "not "
-	}
-	lowerBound := "N/A"
-	if r.MinSet {
-		lowerBound = fmt.Sprintf("%d", r.Min)
-	}
-	upperBound := "N/A"
-	if r.MaxSet {
-		upperBound = fmt.Sprintf("%d", r.Max)
-	}
-	return fmt.Sprintf("%v %sin [%s, %s]", v, cond, lowerBound, upperBound)
-}
-
 // These are the specializedrules
 type intRule struct {
 	Ref       *Rule
 	Value     Range
-	Current   int64
+	Current   []int64
 	Satisfied bool
 }
 
@@ -126,17 +113,19 @@ type intRule struct {
 //   if even this lookup fails, we mark the path as bogus.
 //   Otherwise we use the zero, default, value for our logic.
 
-func decodeInt64(obj interface{}, vm, ref *k6tv1.VirtualMachine) (int64, error) {
+// The first argument is either a single literal integer or a JSON path to one or more integers.
+// Currently the function does not support multiple literal integers.
+func decodeInts(obj interface{}, vm, ref *k6tv1.VirtualMachine) ([]int64, error) {
 	if val, ok := toInt64(obj); ok {
-		return val, nil
+		return []int64{val}, nil
 	}
 
 	jsonPath, ok := obj.(string)
 	if !ok {
-		return 0, fmt.Errorf("unsupported type %v (%v)", obj, reflect.TypeOf(obj).Name())
+		return nil, fmt.Errorf("unsupported type %v (%v)", obj, reflect.TypeOf(obj).Name())
 	}
 	if !isJSONPath(jsonPath) {
-		return 0, fmt.Errorf("parameter is not JSONPath: %v", jsonPath)
+		return nil, fmt.Errorf("parameter is not JSONPath: %v", jsonPath)
 	}
 
 	v, err := decodeInt64FromJSONPath(jsonPath, vm)
@@ -146,9 +135,22 @@ func decodeInt64(obj interface{}, vm, ref *k6tv1.VirtualMachine) (int64, error) 
 	return v, err
 }
 
-func decodeString(s string, vm, ref *k6tv1.VirtualMachine) (string, error) {
+func decodeInt(obj interface{}, vm, ref *k6tv1.VirtualMachine) (int64, error) {
+	v, err := decodeInts(obj, vm, ref)
+	if err != nil {
+		return 0, err
+	}
+	if len(v) != 1 {
+		return 0, fmt.Errorf("expected one value, found %v", len(v))
+	}
+	return v[0], nil
+}
+
+// The first argument is either a single literal string or a JSON path to one or more strings.
+// Currently the function does not support multiple literal strings.
+func decodeStrings(s string, vm, ref *k6tv1.VirtualMachine) ([]string, error) {
 	if !isJSONPath(s) {
-		return s, nil
+		return []string{s}, nil
 	}
 	v, err := decodeJSONPathString(s, vm)
 	if err != nil {
@@ -157,42 +159,43 @@ func decodeString(s string, vm, ref *k6tv1.VirtualMachine) (string, error) {
 	return v, err
 }
 
-func decodeInt64FromJSONPath(jsonPath string, vm *k6tv1.VirtualMachine) (int64, error) {
-	path, err := NewPath(jsonPath)
+func decodeString(s string, vm, ref *k6tv1.VirtualMachine) (string, error) {
+	vals, err := decodeStrings(s, vm, ref)
 	if err != nil {
-		return 0, err
+		return "", err
 	}
-	err = path.Find(vm)
-	if err != nil {
-		return 0, err
-	}
-	if path.Len() != 1 {
-		return 0, fmt.Errorf("expected one value, found %v", path.Len())
-	}
-	vals, err := path.AsInt64()
-	if err != nil {
-		return 0, err
+	if len(vals) != 1 {
+		return "", fmt.Errorf("expected one value, found %v", len(vals))
 	}
 	return vals[0], nil
 }
 
-func decodeJSONPathString(jsonPath string, vm *k6tv1.VirtualMachine) (string, error) {
+func decodeInt64FromJSONPath(jsonPath string, vm *k6tv1.VirtualMachine) ([]int64, error) {
+	path, err := findJsonPath(jsonPath, vm)
+	if err != nil {
+		return nil, err
+	}
+	return path.AsInt64()
+}
+
+func decodeJSONPathString(jsonPath string, vm *k6tv1.VirtualMachine) ([]string, error) {
+	path, err := findJsonPath(jsonPath, vm)
+	if err != nil {
+		return nil, err
+	}
+	return path.AsString()
+}
+
+func findJsonPath(jsonPath string, vm *k6tv1.VirtualMachine) (*Path, error) {
 	path, err := NewPath(jsonPath)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	err = path.Find(vm)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	if path.Len() != 1 {
-		return "", fmt.Errorf("expected one value, found %v", path.Len())
-	}
-	vals, err := path.AsString()
-	if err != nil {
-		return "", err
-	}
-	return vals[0], nil
+	return path, nil
 }
 
 func NewIntRule(r *Rule, vm, ref *k6tv1.VirtualMachine) (RuleApplier, error) {
@@ -205,23 +208,48 @@ func NewIntRule(r *Rule, vm, ref *k6tv1.VirtualMachine) (RuleApplier, error) {
 }
 
 func (ir *intRule) Apply(vm, ref *k6tv1.VirtualMachine) (bool, error) {
-	v, err := decodeInt64(ir.Ref.Path, vm, ref)
+	vals, err := decodeInts(ir.Ref.Path, vm, ref)
 	if err != nil {
 		return false, err
 	}
-	ir.Current = v
-	ir.Satisfied = ir.Value.Includes(ir.Current)
+	if len(vals) == 0 {
+		return false, ErrNoValuesFound
+	}
+
+	ir.Current = vals
+	satisfied := true
+	for _, val := range vals {
+		if !ir.Value.Includes(val) {
+			satisfied = false
+			break
+		}
+	}
+
+	ir.Satisfied = satisfied
 	return ir.Satisfied, nil
 }
 
 func (ir *intRule) String() string {
-	return ir.Value.ToString(ir.Current)
+	lowerBound := "N/A"
+	if ir.Value.MinSet {
+		lowerBound = strconv.FormatInt(ir.Value.Min, 10)
+	}
+	upperBound := "N/A"
+	if ir.Value.MaxSet {
+		upperBound = strconv.FormatInt(ir.Value.Max, 10)
+	}
+
+	if ir.Satisfied {
+		return fmt.Sprintf("All values %v are in interval [%s, %s]", ir.Current, lowerBound, upperBound)
+	} else {
+		return fmt.Sprintf("Some of values %v are not in interval [%s, %s]", ir.Current, lowerBound, upperBound)
+	}
 }
 
 type stringRule struct {
 	Ref       *Rule
 	Length    Range
-	Current   string
+	Current   []string
 	Satisfied bool
 }
 
@@ -235,23 +263,48 @@ func NewStringRule(r *Rule, vm, ref *k6tv1.VirtualMachine) (RuleApplier, error) 
 }
 
 func (sr *stringRule) Apply(vm, ref *k6tv1.VirtualMachine) (bool, error) {
-	v, err := decodeString(sr.Ref.Path, vm, ref)
+	vals, err := decodeStrings(sr.Ref.Path, vm, ref)
 	if err != nil {
 		return false, err
 	}
-	sr.Current = v
-	sr.Satisfied = sr.Length.Includes(int64(len(sr.Current)))
+	if len(vals) == 0 {
+		return false, ErrNoValuesFound
+	}
+
+	sr.Current = vals
+	satisfied := true
+	for _, val := range vals {
+		if !sr.Length.Includes(int64(len(val))) {
+			satisfied = false
+			break
+		}
+	}
+
+	sr.Satisfied = satisfied
 	return sr.Satisfied, nil
 }
 
 func (sr *stringRule) String() string {
-	return sr.Length.ToString(int64(len(sr.Current)))
+	lowerBound := "N/A"
+	if sr.Length.MinSet {
+		lowerBound = strconv.FormatInt(sr.Length.Min, 10)
+	}
+	upperBound := "N/A"
+	if sr.Length.MaxSet {
+		upperBound = strconv.FormatInt(sr.Length.Max, 10)
+	}
+
+	if sr.Satisfied {
+		return fmt.Sprintf("Lengts of all strings are in interval [%s, %s]", lowerBound, upperBound)
+	} else {
+		return fmt.Sprintf("Lengths of some strings are not in interval [%s, %s]", lowerBound, upperBound)
+	}
 }
 
 type enumRule struct {
 	Ref       *Rule
 	Values    []string
-	Current   string
+	Current   []string
 	Satisfied bool
 }
 
@@ -268,33 +321,48 @@ func NewEnumRule(r *Rule, vm, ref *k6tv1.VirtualMachine) (RuleApplier, error) {
 }
 
 func (er *enumRule) Apply(vm, ref *k6tv1.VirtualMachine) (bool, error) {
-	v, err := decodeString(er.Ref.Path, vm, ref)
+	vals, err := decodeStrings(er.Ref.Path, vm, ref)
 	if err != nil {
 		return false, err
 	}
-	er.Current = v
-	for _, v := range er.Values {
-		if er.Current == v {
-			er.Satisfied = true
-			return er.Satisfied, nil
-		}
+	if len(vals) == 0 {
+		return false, ErrNoValuesFound
 	}
-	er.Satisfied = false // enforce
+
+	er.Current = vals
+	er.Satisfied = containsOnly(vals, er.Values)
 	return er.Satisfied, nil
 }
 
-func (er *enumRule) String() string {
-	cond := ""
-	if !er.Satisfied {
-		cond = "not "
+func containsOnly(data []string, expected []string) bool {
+outerLoop:
+	for _, val := range data {
+		for _, expectedVal := range expected {
+			if val == expectedVal {
+				continue outerLoop
+			}
+		}
+		return false
 	}
-	return fmt.Sprintf("%s %sin [%s]", er.Current, cond, strings.Join(er.Values, ", "))
+	return true
+}
+
+func (er *enumRule) String() string {
+	if er.Satisfied {
+		return fmt.Sprintf("All [%s] are in [%s]",
+			strings.Join(er.Current, ", "),
+			strings.Join(er.Values, ", "))
+	} else {
+		return fmt.Sprintf("Some of [%s] are not in [%s]",
+			strings.Join(er.Current, ", "),
+			strings.Join(er.Values, ", "))
+	}
 }
 
 type regexRule struct {
 	Ref       *Rule
 	Regex     *regexp.Regexp
-	Current   string
+	Current   []string
 	Satisfied bool
 }
 
@@ -311,19 +379,31 @@ func NewRegexRule(r *Rule) (RuleApplier, error) {
 }
 
 func (rr *regexRule) Apply(vm, ref *k6tv1.VirtualMachine) (bool, error) {
-	v, err := decodeString(rr.Ref.Path, vm, ref)
+	vals, err := decodeStrings(rr.Ref.Path, vm, ref)
 	if err != nil {
 		return false, err
 	}
-	rr.Current = v
-	rr.Satisfied = rr.Regex.MatchString(rr.Current)
+	if len(vals) == 0 {
+		return false, ErrNoValuesFound
+	}
+
+	rr.Current = vals
+	satisfied := true
+	for _, val := range vals {
+		if !rr.Regex.MatchString(val) {
+			satisfied = false
+			break
+		}
+	}
+
+	rr.Satisfied = satisfied
 	return rr.Satisfied, nil
 }
 
 func (rr *regexRule) String() string {
-	cond := ""
-	if !rr.Satisfied {
-		cond = "not "
+	if rr.Satisfied {
+		return fmt.Sprintf("All [%s] match %s", strings.Join(rr.Current, ", "), rr.Regex)
+	} else {
+		return fmt.Sprintf("Some of [%s] do not match %s", strings.Join(rr.Current, ", "), rr.Regex)
 	}
-	return fmt.Sprintf("%s %smatches %s", rr.Current, cond, rr.Regex)
 }

--- a/pkg/validation/specialized.go
+++ b/pkg/validation/specialized.go
@@ -293,15 +293,20 @@ func (er *enumRule) String() string {
 
 type regexRule struct {
 	Ref       *Rule
-	Regex     string
+	Regex     *regexp.Regexp
 	Current   string
 	Satisfied bool
 }
 
 func NewRegexRule(r *Rule) (RuleApplier, error) {
+	regex, err := regexp.Compile(r.Regex)
+	if err != nil {
+		return nil, err
+	}
+
 	return &regexRule{
 		Ref:   r,
-		Regex: r.Regex,
+		Regex: regex,
 	}, nil
 }
 
@@ -311,8 +316,8 @@ func (rr *regexRule) Apply(vm, ref *k6tv1.VirtualMachine) (bool, error) {
 		return false, err
 	}
 	rr.Current = v
-	rr.Satisfied, err = regexp.MatchString(rr.Regex, rr.Current)
-	return rr.Satisfied, err
+	rr.Satisfied = rr.Regex.MatchString(rr.Current)
+	return rr.Satisfied, nil
 }
 
 func (rr *regexRule) String() string {

--- a/pkg/validation/specialized_test.go
+++ b/pkg/validation/specialized_test.go
@@ -11,7 +11,66 @@ import (
 )
 
 var _ = Describe("Specialized", func() {
-	Context("With invvalid data", func() {
+	Context("With valid data", func() {
+
+		var (
+			vmCirros *k6tv1.VirtualMachine
+			vmRef    *k6tv1.VirtualMachine
+		)
+
+		BeforeEach(func() {
+			vmCirros = NewVMCirros()
+			vmRef = k6tobjs.NewDefaultVirtualMachine()
+		})
+
+		It("Should apply simple integer rules", func() {
+			r := validation.Rule{
+				Rule:    "integer",
+				Name:    "EnoughMemory",
+				Path:    "jsonpath::.spec.domain.resources.requests.memory",
+				Message: "Memory size not specified",
+				Min:     64 * 1024 * 1024,
+				Max:     512 * 1024 * 1024,
+			}
+			expectRuleApplicationSuccess(&r, vmCirros, vmRef)
+		})
+
+		It("Should apply simple string rules", func() {
+			r := validation.Rule{
+				Rule:      "string",
+				Name:      "HasChipset",
+				Path:      "jsonpath::.spec.domain.machine.type",
+				Message:   "machine type must be specified",
+				MinLength: 1,
+				MaxLength: 32,
+			}
+			expectRuleApplicationSuccess(&r, vmCirros, vmRef)
+		})
+
+		It("Should apply simple enum rules", func() {
+			r := validation.Rule{
+				Rule:    "enum",
+				Name:    "SupportedChipset",
+				Path:    "jsonpath::.spec.domain.machine.type",
+				Message: "machine type must be a supported value",
+				Values:  []string{"q35"},
+			}
+			expectRuleApplicationSuccess(&r, vmCirros, vmRef)
+		})
+
+		It("Should apply simple regex rules", func() {
+			r := validation.Rule{
+				Rule:    "regex",
+				Name:    "SupportedChipset",
+				Path:    "jsonpath::.spec.domain.machine.type",
+				Message: "machine type must be a supported value",
+				Regex:   "q35|440fx",
+			}
+			expectRuleApplicationSuccess(&r, vmCirros, vmRef)
+		})
+	})
+
+	Context("With invalid data", func() {
 
 		var (
 			vmCirros *k6tv1.VirtualMachine
@@ -38,80 +97,6 @@ var _ = Describe("Specialized", func() {
 			Expect(err).To(Not(BeNil()))
 			Expect(ra).To(BeNil())
 		})
-	})
-
-	Context("With valid data", func() {
-
-		var (
-			vmCirros *k6tv1.VirtualMachine
-			vmRef    *k6tv1.VirtualMachine
-		)
-
-		BeforeEach(func() {
-			vmCirros = NewVMCirros()
-			vmRef = k6tobjs.NewDefaultVirtualMachine()
-		})
-
-		It("Should apply simple integer rules", func() {
-			r := validation.Rule{
-				Rule:    "integer",
-				Name:    "EnoughMemory",
-				Path:    "jsonpath::.spec.domain.resources.requests.memory",
-				Message: "Memory size not specified",
-				Min:     64 * 1024 * 1024,
-				Max:     512 * 1024 * 1024,
-			}
-
-			checkRuleApplication(&r, vmCirros, vmRef, true)
-		})
-
-		It("Should apply simple string rules", func() {
-			r := validation.Rule{
-				Rule:      "string",
-				Name:      "HasChipset",
-				Path:      "jsonpath::.spec.domain.machine.type",
-				Message:   "machine type must be specified",
-				MinLength: 1,
-				MaxLength: 32,
-			}
-			checkRuleApplication(&r, vmCirros, vmRef, true)
-		})
-
-		It("Should apply simple enum rules", func() {
-			r := validation.Rule{
-				Rule:    "enum",
-				Name:    "SupportedChipset",
-				Path:    "jsonpath::.spec.domain.machine.type",
-				Message: "machine type must be a supported value",
-				Values:  []string{"q35"},
-			}
-			checkRuleApplication(&r, vmCirros, vmRef, true)
-		})
-
-		It("Should apply simple regex rules", func() {
-			r := validation.Rule{
-				Rule:    "regex",
-				Name:    "SupportedChipset",
-				Path:    "jsonpath::.spec.domain.machine.type",
-				Message: "machine type must be a supported value",
-				Regex:   "q35|440fx",
-			}
-			checkRuleApplication(&r, vmCirros, vmRef, true)
-
-		})
-	})
-
-	Context("With INvalid data", func() {
-
-		var (
-			vmCirros *k6tv1.VirtualMachine
-			vmRef    *k6tv1.VirtualMachine
-		)
-
-		BeforeEach(func() {
-			vmCirros = NewVMCirros()
-			vmRef = k6tobjs.NewDefaultVirtualMachine()
-		})
 
 		It("Should fail simple integer rules", func() {
 			r1 := validation.Rule{
@@ -122,7 +107,7 @@ var _ = Describe("Specialized", func() {
 				Valid:   "jsonpath::.spec.domain.this.path.does.not.exist",
 				Min:     512 * 1024 * 1024,
 			}
-			checkRuleApplication(&r1, vmCirros, vmRef, false)
+			expectRuleApplicationFailure(&r1, vmCirros, vmRef)
 
 			r2 := validation.Rule{
 				Rule:    "integer",
@@ -132,7 +117,7 @@ var _ = Describe("Specialized", func() {
 				Valid:   "jsonpath::.spec.domain.this.path.does.not.exist",
 				Max:     64 * 1024 * 1024,
 			}
-			checkRuleApplication(&r2, vmCirros, vmRef, false)
+			expectRuleApplicationFailure(&r2, vmCirros, vmRef)
 		})
 
 		It("Should apply simple string rules", func() {
@@ -143,7 +128,7 @@ var _ = Describe("Specialized", func() {
 				Message:   "machine type must be specified",
 				MinLength: 64,
 			}
-			checkRuleApplication(&r1, vmCirros, vmRef, false)
+			expectRuleApplicationFailure(&r1, vmCirros, vmRef)
 
 			r2 := validation.Rule{
 				Rule:      "string",
@@ -152,8 +137,7 @@ var _ = Describe("Specialized", func() {
 				Message:   "machine type must be specified",
 				MaxLength: 1,
 			}
-			checkRuleApplication(&r2, vmCirros, vmRef, false)
-
+			expectRuleApplicationFailure(&r2, vmCirros, vmRef)
 		})
 
 		It("Should apply simple enum rules", func() {
@@ -164,7 +148,7 @@ var _ = Describe("Specialized", func() {
 				Message: "machine type must be a supported value",
 				Values:  []string{"foo", "bar"},
 			}
-			checkRuleApplication(&r, vmCirros, vmRef, false)
+			expectRuleApplicationFailure(&r, vmCirros, vmRef)
 		})
 
 		It("Should apply simple regex rules", func() {
@@ -175,15 +159,21 @@ var _ = Describe("Specialized", func() {
 				Message: "machine type must be a supported value",
 				Regex:   "\\d[a-z]+\\d\\d",
 			}
-			checkRuleApplication(&r, vmCirros, vmRef, false)
-
+			expectRuleApplicationFailure(&r, vmCirros, vmRef)
 		})
 	})
 
 })
 
-func checkRuleApplication(r *validation.Rule, vm, ref *k6tv1.VirtualMachine, expected bool) {
+func expectRuleApplicationSuccess(r *validation.Rule, vm, ref *k6tv1.VirtualMachine) {
+	checkRuleApplication(r, vm, ref, true)
+}
 
+func expectRuleApplicationFailure(r *validation.Rule, vm, ref *k6tv1.VirtualMachine) {
+	checkRuleApplication(r ,vm, ref, false)
+}
+
+func checkRuleApplication(r *validation.Rule, vm, ref *k6tv1.VirtualMachine, expected bool) {
 	ra, err := r.Specialize(vm, ref)
 	Expect(err).To(BeNil())
 	Expect(ra).To(Not(BeNil()))


### PR DESCRIPTION
The rules are evaluated for all values pointed to by the JSON path.

For example, the following rule will be evaluated for all disks:
```json
{
    "name": "windows-disk-bus",
    "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
    "rule": "enum",
    "message": "disk bus has to be either virtio or sata",
    "values": ["virtio", "sata"]
}
```