### PR TITLE
Set default values for CPU sockets, cores and threads

### DIFF
--- a/functests/14-test-with-template-with-incomplate-cpu-info.sh
+++ b/functests/14-test-with-template-with-incomplate-cpu-info.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+{
+RET=1
+$KUBECTL create -n default -f manifests/template-with-rules.yaml || exit 2
+sleep 1s
+$KUBECTL create -f manifests/14-vm-from-template-with-incomplete-cpu-info.yaml
+if $KUBECTL get vm vm-test-14; then
+	RET=0
+	$KUBECTL delete vm vm-test-14
+fi
+$KUBECTL delete -n default -f manifests/template-with-rules.yaml
+exit $RET
+}

--- a/functests/manifests/14-vm-from-template-with-incomplete-cpu-info.yaml
+++ b/functests/manifests/14-vm-from-template-with-incomplete-cpu-info.yaml
@@ -1,0 +1,37 @@
+apiVersion: kubevirt.io/v1alpha3
+kind: VirtualMachine
+metadata:
+  creationTimestamp: null
+  labels:
+    kubevirt.io/vm: vm-test-14
+  name: vm-test-14
+  annotations:
+    vm.kubevirt.io/template: fedora-desktop-small-with-rules
+    vm.kubevirt.io/template-namespace: default
+spec:
+  running: false
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        kubevirt.io/vm: vm-test-14
+    spec:
+      domain:
+        cpu:
+          sockets: 1
+          # cores and threads should be 1 by default, so the rule should pass
+        devices:
+          interfaces:
+            - name: default
+              bridge: {}
+        machine:
+          type: "q35"
+        resources:
+          requests:
+            memory: 128M
+      networks:
+        - name: default
+          pod: {}
+      evictionStrategy: LiveMigrate
+      terminationGracePeriodSeconds: 0
+status: {}

--- a/pkg/webhooks/validating/admission.go
+++ b/pkg/webhooks/validating/admission.go
@@ -36,6 +36,9 @@ func ValidateVMTemplate(rules []validation.Rule, newVM, oldVM *k6tv1.VirtualMach
 		log.Log.V(8).Infof("no admission rules for: %s", newVM.Name)
 		return causes
 	}
+
+	setDefaultValues(newVM)
+
 	buf := new(bytes.Buffer)
 	ev := validation.Evaluator{Sink: buf}
 	res := ev.Evaluate(rules, newVM)
@@ -45,4 +48,19 @@ func ValidateVMTemplate(rules []validation.Rule, newVM, oldVM *k6tv1.VirtualMach
 		return causes
 	}
 	return res.ToStatusCauses()
+}
+
+func setDefaultValues(vm *k6tv1.VirtualMachine) {
+	vmSpec := vm.Spec.Template.Spec
+	if vmSpec.Domain.CPU != nil {
+		if vmSpec.Domain.CPU.Sockets == 0 {
+			vmSpec.Domain.CPU.Sockets = 1
+		}
+		if vmSpec.Domain.CPU.Cores == 0 {
+			vmSpec.Domain.CPU.Cores = 1
+		}
+		if vmSpec.Domain.CPU.Threads == 0 {
+			vmSpec.Domain.CPU.Threads = 1
+		}
+	}
 }

--- a/pkg/webhooks/validating/admission_test.go
+++ b/pkg/webhooks/validating/admission_test.go
@@ -3,11 +3,7 @@ package validating_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	//	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
-
-	//	templatev1 "github.com/openshift/api/template/v1"
-
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k6tv1 "kubevirt.io/client-go/api/v1"
 
 	"github.com/fromanirh/kubevirt-template-validator/pkg/validation"
@@ -23,6 +19,66 @@ var _ = Describe("Admission", func() {
 
 			causes := validating.ValidateVMTemplate(rules, &newVM, &oldVM)
 
+			Expect(len(causes)).To(Equal(0))
+		})
+	})
+
+	Context("Default values", func() {
+		var vm k6tv1.VirtualMachine
+
+		BeforeEach(func() {
+			vm = k6tv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-vm",
+				},
+				Spec: k6tv1.VirtualMachineSpec{
+					Template: &k6tv1.VirtualMachineInstanceTemplateSpec{
+						Spec: k6tv1.VirtualMachineInstanceSpec{
+							Domain: k6tv1.DomainSpec{
+								CPU: &k6tv1.CPU{},
+							},
+						},
+					},
+				},
+			}
+		})
+
+		It("should set default sockets", func() {
+			rules := []validation.Rule{{
+				Name:    "test-sockets-default",
+				Path:    "jsonpath::.spec.domain.cpu.sockets",
+				Rule:    "integer",
+				Message: "invalid number of sockets",
+				Min:     1,
+			}}
+
+			causes := validating.ValidateVMTemplate(rules, &vm, &k6tv1.VirtualMachine{})
+			Expect(len(causes)).To(Equal(0))
+		})
+
+		It("should set default cores", func() {
+			rules := []validation.Rule{{
+				Name:    "test-cores-default",
+				Path:    "jsonpath::.spec.domain.cpu.cores",
+				Rule:    "integer",
+				Message: "invalid number of cores",
+				Min:     1,
+			}}
+
+			causes := validating.ValidateVMTemplate(rules, &vm, &k6tv1.VirtualMachine{})
+			Expect(len(causes)).To(Equal(0))
+		})
+
+		It("should set default threads", func() {
+			rules := []validation.Rule{{
+				Name:    "test-threads-default",
+				Path:    "jsonpath::.spec.domain.cpu.threads",
+				Rule:    "integer",
+				Message: "invalid number of threads",
+				Min:     1,
+			}}
+
+			causes := validating.ValidateVMTemplate(rules, &vm, &k6tv1.VirtualMachine{})
 			Expect(len(causes)).To(Equal(0))
 		})
 	})


### PR DESCRIPTION
If the fields are not defined in yaml, they have the default value 0.
In this case kubevirt treats 0 as 1, so template validator should too.

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1870541

**Release note**:
```release-note
Template validator correctly evaluates rules if CPU sockets, cores or threads are not defined.
```
